### PR TITLE
Use devel branch in links

### DIFF
--- a/inst/book/_output.yml
+++ b/inst/book/_output.yml
@@ -9,9 +9,9 @@ bookdown::gitbook:
       after: |
         <li><a href="https://bioconductor.org" target="blank">Published by Bioconductor</a></li>
     download: null
-    edit: https://github.com/OSCA-source/OSCA.basic/edit/master/inst/book/%s
-    view: https://github.com/OSCA-source/OSCA.basic/blob/master/inst/book/%s
-    history: https://github.com/OSCA-source/OSCA.basic/commits/master/inst/book/%s
+    edit: https://github.com/OSCA-source/OSCA.basic/edit/devel/inst/book/%s
+    view: https://github.com/OSCA-source/OSCA.basic/blob/devel/inst/book/%s
+    history: https://github.com/OSCA-source/OSCA.basic/commits/devel/inst/book/%s
     sharing:
       github: yes
       facebook: yes


### PR DESCRIPTION
I assume after Bioconductor renaming of the branches this got updated but not in the configuration files. This should make it easier to send PR/edit the book.