### PR TITLE
Correct mitochondrial gene identification.

### DIFF
--- a/inst/book/quality-control.Rmd
+++ b/inst/book/quality-control.Rmd
@@ -72,7 +72,7 @@ Finally, the `altexps_ERCC_percent` column contains the percentage of reads mapp
 library(SingleCellExperiment)
 # Identifying the mitochondrial transcripts in our SingleCellExperiment.
 location <- rowRanges(sce.416b)
-is.mito <- any(seqnames(location)=="MT")
+is.mito <- as.character(seqnames(location))=="MT"
 
 library(scuttle)
 df <- perCellQCMetrics(sce.416b, subsets=list(Mito=is.mito))

--- a/inst/book/quality-control.Rmd
+++ b/inst/book/quality-control.Rmd
@@ -73,9 +73,10 @@ library(SingleCellExperiment)
 # Identifying the mitochondrial transcripts in our SingleCellExperiment.
 location <- rowRanges(sce.416b)
 is.mito <- as.character(seqnames(location))=="MT"
+mito.genes <- rownames(sce.416b)[which(is.mito)]
 
 library(scuttle)
-df <- perCellQCMetrics(sce.416b, subsets=list(Mito=is.mito))
+df <- perCellQCMetrics(sce.416b, subsets=list(Mito=mito.genes))
 summary(df$sum)
 summary(df$detected)
 summary(df$subsets_Mito_percent)
@@ -87,7 +88,7 @@ This computes and appends the per-cell QC statistics to the `colData` of the `Si
 allowing us to retain all relevant information in a single object for later manipulation.
 
 ```{r}
-sce.416b <- addPerCellQCMetrics(sce.416b, subsets=list(Mito=is.mito))
+sce.416b <- addPerCellQCMetrics(sce.416b, subsets=list(Mito=mito.genes))
 colnames(colData(sce.416b))
 ```
 

--- a/inst/book/quality-control.Rmd
+++ b/inst/book/quality-control.Rmd
@@ -72,11 +72,10 @@ Finally, the `altexps_ERCC_percent` column contains the percentage of reads mapp
 library(SingleCellExperiment)
 # Identifying the mitochondrial transcripts in our SingleCellExperiment.
 location <- rowRanges(sce.416b)
-is.mito <- as.character(seqnames(location))=="MT"
-mito.genes <- rownames(sce.416b)[which(is.mito)]
+is.mito <- sapply(seqnames(location)=="MT", any)
 
 library(scuttle)
-df <- perCellQCMetrics(sce.416b, subsets=list(Mito=mito.genes))
+df <- perCellQCMetrics(sce.416b, subsets=list(Mito=is.mito))
 summary(df$sum)
 summary(df$detected)
 summary(df$subsets_Mito_percent)
@@ -88,7 +87,7 @@ This computes and appends the per-cell QC statistics to the `colData` of the `Si
 allowing us to retain all relevant information in a single object for later manipulation.
 
 ```{r}
-sce.416b <- addPerCellQCMetrics(sce.416b, subsets=list(Mito=mito.genes))
+sce.416b <- addPerCellQCMetrics(sce.416b, subsets=list(Mito=is.mito))
 colnames(colData(sce.416b))
 ```
 


### PR DESCRIPTION
I followed the OSCA introduction and saw that 100% of genes were classified as mitochondrial.
The GRanges accessor `seqnames`  returns a `factor-Rle` object and `any` collapses it to a single 
logical value, which usually will be TRUE.

Not sure if something changed in GenomicRanges or if `any` has special behavious for GRangesList objects,
but the book shows adding `rowRanges` as just a GRanges object. The exact conversion to an index
can be done differently, and maybe faster, like so `as.logical(seqnames(location)=="MT)`, but I don't 
see much difference in practice.
